### PR TITLE
Move initFirestore script to src/lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:coverage": "jest --coverage",
     "prepare": "husky install",
     "ci": "npm install --legacy-peer-deps",
-    "init:firestore": "node ./scripts/initFirestore.js"
+    "init:firestore": "npm run build && node dist/lib/initFirestore.js"
   },
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.11",

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,7 +1,11 @@
+const env = typeof import.meta !== 'undefined' && (import.meta as any).env ? (import.meta as any).env : process.env;
+
 export const firebaseConfig = {
-  apiKey: import.meta.env.VITE_FIREBASE_API_KEY,
-  authDomain: `${import.meta.env.VITE_FIREBASE_PROJECT_ID}.firebaseapp.com`,
-  projectId: import.meta.env.VITE_FIREBASE_PROJECT_ID,
-  storageBucket: `${import.meta.env.VITE_FIREBASE_PROJECT_ID}.appspot.com`,
-  appId: import.meta.env.VITE_FIREBASE_APP_ID,
+  apiKey: env.VITE_FIREBASE_API_KEY,
+  authDomain: `${env.VITE_FIREBASE_PROJECT_ID}.firebaseapp.com`,
+  projectId: env.VITE_FIREBASE_PROJECT_ID,
+  storageBucket: `${env.VITE_FIREBASE_PROJECT_ID}.appspot.com`,
+  appId: env.VITE_FIREBASE_APP_ID,
 };
+
+

--- a/src/lib/initFirestore.ts
+++ b/src/lib/initFirestore.ts
@@ -1,27 +1,23 @@
 import { readFile } from 'node:fs/promises';
 import path from 'node:path';
-import { initializeApp } from 'firebase-admin/app';
-import { getFirestore } from 'firebase-admin/firestore';
+import { db } from './firebase';
+import { setDoc, doc } from 'firebase/firestore';
 
 /**
  * Migration script to create base Firestore collections.
  *
  * Usage:
- *  node scripts/initFirestore.js
+ *   npm run init:firestore
  */
 async function main() {
-  const app = initializeApp();
-  const db = getFirestore(app);
-
   const dataDir = path.resolve('data');
-
 
   // Import architectures
   const archFile = path.join(dataDir, 'architectures.json');
   const architectures = JSON.parse(await readFile(archFile, 'utf-8'));
   for (const arch of architectures) {
     const id = arch.id || arch.slug;
-    await db.collection('architectures').doc(String(id)).set(arch);
+    await setDoc(doc(db, 'architectures', String(id)), arch);
   }
 
   // Import languages
@@ -29,7 +25,7 @@ async function main() {
   const languages = JSON.parse(await readFile(langFile, 'utf-8'));
   for (const lang of languages) {
     const id = lang.id || lang.slug;
-    await db.collection('languages').doc(String(id)).set(lang);
+    await setDoc(doc(db, 'languages', String(id)), lang);
   }
 
   console.log('Base collections created successfully');
@@ -39,3 +35,4 @@ main().catch((err) => {
   console.error(err);
   process.exit(1);
 });
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "types": ["@testing-library/jest-dom"],
+    "types": ["@testing-library/jest-dom", "node"],
     "target": "ES2020",
     "module": "ESNext",
     "lib": [


### PR DESCRIPTION
## Summary
- move `initFirestore` to `src/lib`
- reuse Firestore client `db`
- handle Node environments in `env.ts`
- update `init:firestore` npm script
- allow Node types in TypeScript config

## Testing
- `npm run lint` *(fails: lint errors)*
- `npm run build`
- `npm run test:coverage` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6851f33bdd10832780b7e2a42b76dedd