### PR TITLE
Fix Firestore init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Para poblar Firestore con las colecciones base de arquitecturas y lenguajes ejec
 npm run init:firestore
 ```
 
-El script utiliza `firebase-admin` y se apoya en las credenciales por defecto de Google.
+El script utiliza `firebase-admin` y se apoya en las credenciales por defecto de Google. Asegúrate de tener las
+variables de entorno `VITE_FIREBASE_*` configuradas antes de ejecutarlo.
+También puedes realizar la migración desde la página `/admin/firebase`.
 
 ## Créditos
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { PatternDetail } from '@/pages/PatternDetail';
 import { Architectures } from '@/pages/Architectures';
 import { Languages } from '@/pages/Languages';
 import { Favorites } from '@/pages/Favorites';
+import { FirebaseAdmin } from '@/pages/FirebaseAdmin';
 import { useEffect } from 'react';
 import { ToastProvider } from './contexts/ToastContext';
 
@@ -54,6 +55,7 @@ function App() {
               <Route path="/architectures" component={Architectures} />
               <Route path="/languages" component={Languages} />
               <Route path="/favorites" component={Favorites} />
+              <Route path="/admin/firebase" component={FirebaseAdmin} />
             </Switch>
           </TooltipProvider>
         </FavoritesProvider>

--- a/src/components/initialize-firestore.tsx
+++ b/src/components/initialize-firestore.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { initFirestore } from '@/lib/initFirestore';
+import { Button } from '@/components/ui/button';
+
+export function InitializeFirestore() {
+  const [status, setStatus] = useState<'idle' | 'running' | 'done' | 'error'>('idle');
+
+  const handleClick = async () => {
+    setStatus('running');
+    try {
+      await initFirestore();
+      setStatus('done');
+    } catch (err) {
+      console.error(err);
+      setStatus('error');
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <Button onClick={handleClick} disabled={status === 'running'}>
+        {status === 'running' ? 'Migrando...' : 'Migrar Firestore'}
+      </Button>
+      {status === 'done' && (
+        <p className="text-green-600 dark:text-green-400">Migración completada.</p>
+      )}
+      {status === 'error' && (
+        <p className="text-red-600 dark:text-red-400">Error al migrar Firestore.</p>
+      )}
+    </div>
+  );
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,4 +1,8 @@
-const env = typeof import.meta !== 'undefined' && (import.meta as any).env ? (import.meta as any).env : process.env;
+type Env = Record<string, string | undefined>;
+const env: Env =
+  typeof import.meta !== 'undefined' && (import.meta as unknown as { env: Env }).env
+    ? (import.meta as unknown as { env: Env }).env
+    : (process.env as Env);
 
 export const firebaseConfig = {
   apiKey: env.VITE_FIREBASE_API_KEY,

--- a/src/lib/initFirestore.ts
+++ b/src/lib/initFirestore.ts
@@ -1,38 +1,65 @@
-import { readFile } from 'node:fs/promises';
-import path from 'node:path';
 import { db } from './firebase';
-import { setDoc, doc } from 'firebase/firestore';
+import { setDoc, doc, getDoc } from 'firebase/firestore';
+import { pathToFileURL } from 'node:url';
 
-/**
- * Migration script to create base Firestore collections.
- *
- * Usage:
- *   npm run init:firestore
- */
-async function main() {
-  const dataDir = path.resolve('data');
+export async function initFirestore(): Promise<void> {
+  if (typeof window === 'undefined') {
+    const { readFile } = await import('node:fs/promises');
+    const path = await import('node:path');
+    const dataDir = path.resolve('data');
 
-  // Import architectures
-  const archFile = path.join(dataDir, 'architectures.json');
-  const architectures = JSON.parse(await readFile(archFile, 'utf-8'));
-  for (const arch of architectures) {
-    const id = arch.id || arch.slug;
-    await setDoc(doc(db, 'architectures', String(id)), arch);
-  }
+    const archFile = path.join(dataDir, 'architectures.json');
+    const architectures = JSON.parse(await readFile(archFile, 'utf-8'));
+    for (const arch of architectures) {
+      const id = arch.id || arch.slug;
+      const ref = doc(db, 'architectures', String(id));
+      const snap = await getDoc(ref);
+      if (!snap.exists()) {
+        await setDoc(ref, arch);
+      }
+    }
 
-  // Import languages
-  const langFile = path.join(dataDir, 'languages.json');
-  const languages = JSON.parse(await readFile(langFile, 'utf-8'));
-  for (const lang of languages) {
-    const id = lang.id || lang.slug;
-    await setDoc(doc(db, 'languages', String(id)), lang);
+    const langFile = path.join(dataDir, 'languages.json');
+    const languages = JSON.parse(await readFile(langFile, 'utf-8'));
+    for (const lang of languages) {
+      const id = lang.id || lang.slug;
+      const ref = doc(db, 'languages', String(id));
+      const snap = await getDoc(ref);
+      if (!snap.exists()) {
+        await setDoc(ref, lang);
+      }
+    }
+  } else {
+    const fetchJson = (file: string) => fetch(file).then((res) => res.json());
+    const architectures = await fetchJson('/data/architectures.json');
+    for (const arch of architectures) {
+      const id = arch.id || arch.slug;
+      const ref = doc(db, 'architectures', String(id));
+      const snap = await getDoc(ref);
+      if (!snap.exists()) {
+        await setDoc(ref, arch);
+      }
+    }
+    const languages = await fetchJson('/data/languages.json');
+    for (const lang of languages) {
+      const id = lang.id || lang.slug;
+      const ref = doc(db, 'languages', String(id));
+      const snap = await getDoc(ref);
+      if (!snap.exists()) {
+        await setDoc(ref, lang);
+      }
+    }
   }
 
   console.log('Base collections created successfully');
 }
 
-main().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
-
+if (
+  typeof process !== 'undefined' &&
+  import.meta.url === pathToFileURL(process.argv[1] || '').href
+) {
+  initFirestore().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/src/pages/FirebaseAdmin.tsx
+++ b/src/pages/FirebaseAdmin.tsx
@@ -1,0 +1,18 @@
+import { Header } from '@/components/header';
+import { Footer } from '@/components/footer';
+import { InitializeFirestore } from '@/components/initialize-firestore';
+
+export function FirebaseAdmin() {
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <Header />
+      <main className="py-16">
+        <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 text-center space-y-6">
+          <h1 className="text-4xl font-bold">Firebase Admin</h1>
+          <InitializeFirestore />
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,6 @@
 import type { Config } from 'tailwindcss';
+import animatePlugin from 'tailwindcss-animate';
+import typography from '@tailwindcss/typography';
 
 export default {
   darkMode: ['class'],
@@ -86,5 +88,5 @@ export default {
       },
     },
   },
-  plugins: [require('tailwindcss-animate'), require('@tailwindcss/typography')],
+  plugins: [animatePlugin, typography],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- update docs to reference `npm run init:firestore`
- remove `init` script alias
- avoid rewriting existing documents during Firestore migration
- type the env loader and switch Tailwind plugins to ESM imports

## Testing
- `npm run test:coverage -- --passWithNoTests`
- `npm run lint` *(fails: no-explicit-any, no-useless-escape, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685276b8145883279ec3257cac2df5d3