### PR TITLE
Improve architecture view

### DIFF
--- a/src/components/architecture-card.tsx
+++ b/src/components/architecture-card.tsx
@@ -1,29 +1,40 @@
-import { Link } from 'wouter';
 import { Badge } from '@/components/ui/badge';
-import type { Architecture } from '@/lib/types';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { PatternMiniCard } from './pattern-mini-card';
+import type { Architecture, Pattern } from '@/lib/types';
 
 interface ArchitectureCardProps {
   architecture: Architecture;
-  patternsCount: number;
+  patterns: Pattern[];
 }
 
-export function ArchitectureCard({ architecture, patternsCount }: ArchitectureCardProps) {
+export function ArchitectureCard({ architecture, patterns }: ArchitectureCardProps) {
   return (
-    <Link href={`/patterns?architecture=${architecture.slug}`}> 
-      <div className="overflow-hidden bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-700 hover:shadow-lg transition-shadow">
-        <div className="p-6 flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <div className={`w-16 h-16 bg-gradient-to-br ${architecture.color} rounded-xl flex items-center justify-center`}>
-              <i className={`fas fa-${architecture.icon} text-white text-2xl`} />
-            </div>
-            <div>
-              <h3 className="text-2xl font-bold text-gray-900 dark:text-white">{architecture.name}</h3>
-              <p className="text-gray-600 dark:text-gray-400 mt-1">{architecture.description}</p>
-            </div>
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-4">
+          <div className={`w-16 h-16 bg-gradient-to-br ${architecture.color} rounded-xl flex items-center justify-center`}>
+            <i className={`fas fa-${architecture.icon} text-white text-2xl`} />
           </div>
-          <Badge variant="secondary">{patternsCount} patrones</Badge>
+          <div className="flex-1">
+            <CardTitle className="mb-2">{architecture.name}</CardTitle>
+            <p className="text-gray-600 dark:text-gray-400">{architecture.description}</p>
+          </div>
+          <Badge variant="secondary" className="ml-auto">
+            {patterns.length} patrones
+          </Badge>
         </div>
-      </div>
-    </Link>
+      </CardHeader>
+      {patterns.length > 0 && (
+        <CardContent>
+          <h4 className="text-lg font-semibold mb-4 text-gray-900 dark:text-white">Patrones relacionados</h4>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {patterns.map((p) => (
+              <PatternMiniCard key={p.slug} pattern={p} />
+            ))}
+          </div>
+        </CardContent>
+      )}
+    </Card>
   );
 }

--- a/src/components/architecture-grid.tsx
+++ b/src/components/architecture-grid.tsx
@@ -10,14 +10,14 @@ export function ArchitectureGrid({ architectures, patterns }: ArchitectureGridPr
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8">
       {architectures.map((architecture) => {
-        const count = patterns.filter((p) =>
+        const related = patterns.filter((p) =>
           p.architectures.includes(architecture.slug)
-        ).length;
+        );
         return (
           <ArchitectureCard
             key={architecture.slug}
             architecture={architecture}
-            patternsCount={count}
+            patterns={related}
           />
         );
       })}

--- a/src/components/pattern-mini-card.tsx
+++ b/src/components/pattern-mini-card.tsx
@@ -1,0 +1,22 @@
+import { Link } from 'wouter';
+import type { Pattern } from '@/lib/types';
+
+interface PatternMiniCardProps {
+  pattern: Pattern;
+}
+
+export function PatternMiniCard({ pattern }: PatternMiniCardProps) {
+  return (
+    <Link href={`/patterns/${pattern.slug}`}>
+      <div className="p-4 border border-gray-200 dark:border-slate-700 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 transition-colors">
+        <div className="flex items-center gap-3 mb-2">
+          <div className={`w-8 h-8 bg-gradient-to-br ${pattern.color} rounded-lg flex items-center justify-center`}>
+            <i className={`fas fa-${pattern.icon} text-white text-xs`}></i>
+          </div>
+          <h5 className="font-medium text-gray-900 dark:text-white">{pattern.name}</h5>
+        </div>
+        <p className="text-sm text-gray-600 dark:text-gray-400">{pattern.description}</p>
+      </div>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- show mini pattern cards inside architecture card
- compute related patterns in `ArchitectureGrid`
- add reusable `PatternMiniCard`

## Testing
- `npm run lint` *(fails: 17 errors, 11 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_6852834216e88327aad93d7f23ecf024