### PR TITLE
Fix architectures page layout

### DIFF
--- a/src/components/architecture-card.tsx
+++ b/src/components/architecture-card.tsx
@@ -1,6 +1,6 @@
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { PatternMiniCard } from './pattern-mini-card';
+import { PatternCard } from './pattern-card';
 import type { Architecture, Pattern } from '@/lib/types';
 
 interface ArchitectureCardProps {
@@ -10,7 +10,7 @@ interface ArchitectureCardProps {
 
 export function ArchitectureCard({ architecture, patterns }: ArchitectureCardProps) {
   return (
-    <Card>
+    <Card className="overflow-hidden">
       <CardHeader>
         <div className="flex items-center gap-4">
           <div className={`w-16 h-16 bg-gradient-to-br ${architecture.color} rounded-xl flex items-center justify-center`}>
@@ -27,10 +27,9 @@ export function ArchitectureCard({ architecture, patterns }: ArchitectureCardPro
       </CardHeader>
       {patterns.length > 0 && (
         <CardContent>
-          <h4 className="text-lg font-semibold mb-4 text-gray-900 dark:text-white">Patrones relacionados</h4>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {patterns.map((p) => (
-              <PatternMiniCard key={p.slug} pattern={p} />
+              <PatternCard key={p.slug} pattern={p} />
             ))}
           </div>
         </CardContent>

--- a/src/pages/Architectures.tsx
+++ b/src/pages/Architectures.tsx
@@ -22,13 +22,17 @@ export function Architectures() {
       <Header />
       <main className="flex-1 py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h1 className="text-4xl font-bold text-gray-900 dark:text-white text-center mb-4">
-            Arquitecturas de Software
-          </h1>
+          <div className="text-center mb-12">
+            <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">
+              Arquitecturas de Software
+            </h1>
+          </div>
           {isLoading ? (
-            <p className="text-center text-gray-500 dark:text-gray-400">
-              Cargando arquitecturas...
-            </p>
+            <div className="text-center py-12">
+              <p className="text-gray-500 dark:text-gray-400 text-lg">
+                Cargando información...
+              </p>
+            </div>
           ) : (
             <ArchitectureGrid architectures={architectures} patterns={patterns} />
           )}


### PR DESCRIPTION
## Summary
- refresh `/architectures` page layout
- show pattern cards in architecture cards

## Testing
- `npm run test:coverage -- --passWithNoTests`
- `npm run lint` *(fails: Fast refresh only works when a file only exports components, and others)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685285fc7f9083279b8be3fb57f950d5