### PR TITLE
Fix languages grid layout

### DIFF
--- a/src/components/language-card.tsx
+++ b/src/components/language-card.tsx
@@ -1,43 +1,29 @@
+import { Link } from 'wouter';
 import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { PatternCard } from './pattern-card';
-import type { Language, Pattern } from '@/lib/types';
+import type { Language } from '@/lib/types';
 
 interface LanguageCardProps {
   language: Language;
-  patterns: Pattern[];
+  patternsCount: number;
 }
 
-export function LanguageCard({ language, patterns }: LanguageCardProps) {
+export function LanguageCard({ language, patternsCount }: LanguageCardProps) {
   return (
-    <Card className="overflow-hidden">
-      <CardHeader>
-        <div className="flex items-center gap-4">
-          <div
-            className={`w-16 h-16 bg-gradient-to-br ${language.color} rounded-xl flex items-center justify-center`}
-          >
-            <i className={`fab fa-${language.icon} text-white text-2xl`} />
+    <Link href={`/patterns?language=${language.slug}`}>
+      <div className="overflow-hidden bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-700 hover:shadow-lg transition-shadow">
+        <div className="p-6 flex items-center justify-between">
+          <div className="flex items-center gap-4">
+            <div className={`w-16 h-16 bg-gradient-to-br ${language.color} rounded-xl flex items-center justify-center`}>
+              <i className={`fab fa-${language.icon} text-white text-2xl`} />
+            </div>
+            <div>
+              <h3 className="text-2xl font-bold text-gray-900 dark:text-white">{language.name}</h3>
+              <p className="text-gray-600 dark:text-gray-400 mt-1">{language.description}</p>
+            </div>
           </div>
-          <div className="flex-1">
-            <CardTitle className="font-semibold tracking-tight text-2xl mb-2">
-              {language.name}
-            </CardTitle>
-            <p className="text-gray-600 dark:text-gray-400">
-              Patrones implementados en {language.name}
-            </p>
-          </div>
-          <Badge variant="secondary" className="ml-auto">
-            {patterns.length} patrones
-          </Badge>
+          <Badge variant="secondary">{patternsCount} patrones</Badge>
         </div>
-      </CardHeader>
-      <CardContent>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-          {patterns.map((p) => (
-            <PatternCard key={p.slug} pattern={p} />
-          ))}
-        </div>
-      </CardContent>
-    </Card>
+      </div>
+    </Link>
   );
 }

--- a/src/components/language-grid.tsx
+++ b/src/components/language-grid.tsx
@@ -8,16 +8,16 @@ interface LanguageGridProps {
 
 export function LanguageGrid({ languages, patterns }: LanguageGridProps) {
   return (
-    <div className="grid gap-8">
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8">
       {languages.map((language) => {
-        const filtered = patterns.filter((p) =>
-          p.languages.includes(language.slug),
-        );
+        const count = patterns.filter((p) =>
+          p.languages.includes(language.slug)
+        ).length;
         return (
           <LanguageCard
             key={language.slug}
             language={language}
-            patterns={filtered}
+            patternsCount={count}
           />
         );
       })}


### PR DESCRIPTION
## Summary
- simplify language card to show just meta info
- restore grid columns for languages

## Testing
- `npm run lint` *(fails: ThemeContext unused vars, patterns-data escape characters)*
- `npm run test:coverage` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_685286179a108327957380b3d0761f7c