### PR TITLE
Fix pattern card links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,7 +51,7 @@ function App() {
 
             <Switch>
               <Route path="/" component={Home} />
-              <Route path="/patterns/:slug" component={PatternDetail} />
+              <Route path="/pattern/:slug" component={PatternDetail} />
               <Route path="/architectures" component={Architectures} />
               <Route path="/languages" component={Languages} />
               <Route path="/favorites" component={Favorites} />

--- a/src/components/pattern-card.tsx
+++ b/src/components/pattern-card.tsx
@@ -80,7 +80,7 @@ export function PatternCard({ pattern }: PatternCardProps) {
 
   return (
     <div className="bg-white dark:bg-slate-800 rounded-xl border border-gray-200 dark:border-slate-700 overflow-hidden pattern-card-hover group relative">
-      <Link href={`/patterns/${pattern.slug}`} className="block">
+      <Link href={`/pattern/${pattern.slug}`} className="block">
         <div className="p-6">
           {/* Header with icon and category badge */}
           <div className="flex items-start justify-between mb-4">

--- a/src/components/pattern-mini-card.tsx
+++ b/src/components/pattern-mini-card.tsx
@@ -7,7 +7,7 @@ interface PatternMiniCardProps {
 
 export function PatternMiniCard({ pattern }: PatternMiniCardProps) {
   return (
-    <Link href={`/patterns/${pattern.slug}`}>
+    <Link href={`/pattern/${pattern.slug}`}>
       <div className="p-4 border border-gray-200 dark:border-slate-700 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-800 transition-colors">
         <div className="flex items-center gap-3 mb-2">
           <div className={`w-8 h-8 bg-gradient-to-br ${pattern.color} rounded-lg flex items-center justify-center`}>

--- a/src/pages/PatternDetail.tsx
+++ b/src/pages/PatternDetail.tsx
@@ -230,7 +230,7 @@ export function PatternDetail() {
                     {pattern.relatedPatterns.map((relatedSlug: string) => {
                       const relatedPattern = allPatterns.find((p) => p.slug === relatedSlug);
                       return relatedPattern ? (
-                        <Link key={relatedSlug} href={`/patterns/${relatedSlug}`}>
+                        <Link key={relatedSlug} href={`/pattern/${relatedSlug}`}>
                           <div className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50 dark:hover:bg-slate-700 transition-colors">
                             <div className={`w-8 h-8 bg-gradient-to-br ${relatedPattern.color} rounded-lg flex items-center justify-center`}>
                               <i className={`fas fa-${relatedPattern.icon} text-white text-xs`}></i>


### PR DESCRIPTION
## Summary
- update link paths for pattern cards
- update related pattern links
- adjust router to use singular `/pattern/:slug` path

## Testing
- `npm run lint` *(fails: no-unused-vars and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68528672d8d88327a2bbc46a29f97d73