### PR TITLE
Improve Architectures and Languages pages

### DIFF
--- a/data/languages.json
+++ b/data/languages.json
@@ -6,7 +6,8 @@
     "icon": "js",
     "color": "from-yellow-400 to-yellow-500",
     "description": "Lenguaje de programación interpretado utilizado principalmente en la web.",
-    "patternsCount": 0
+    "patternsCount": 0,
+    "isFramework": false
   },
   {
     "id": 2,
@@ -15,7 +16,8 @@
     "icon": "php",
     "color": "from-indigo-500 to-purple-600",
     "description": "Lenguaje de programación del lado del servidor enfocado en la web.",
-    "patternsCount": 0
+    "patternsCount": 0,
+    "isFramework": false
   },
   {
     "id": 3,
@@ -24,7 +26,8 @@
     "icon": "react",
     "color": "from-sky-500 to-blue-600",
     "description": "Biblioteca de JavaScript para construir interfaces de usuario.",
-    "patternsCount": 0
+    "patternsCount": 0,
+    "isFramework": true
   },
   {
     "id": 4,
@@ -33,7 +36,8 @@
     "icon": "vuejs",
     "color": "from-green-500 to-emerald-600",
     "description": "Framework progresivo de JavaScript para interfaces de usuario.",
-    "patternsCount": 0
+    "patternsCount": 0,
+    "isFramework": true
   },
   {
     "id": 5,
@@ -42,6 +46,7 @@
     "icon": "symfony",
     "color": "from-gray-500 to-gray-700",
     "description": "Framework PHP para aplicaciones web robustas.",
-    "patternsCount": 0
+    "patternsCount": 0,
+    "isFramework": true
   }
 ]

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -69,4 +69,5 @@ export interface Language {
   color: string;
   description: string;
   patternsCount: number;
+  isFramework: boolean;
 }

--- a/src/pages/Architectures.tsx
+++ b/src/pages/Architectures.tsx
@@ -3,7 +3,9 @@ import { getArchitectures, getPatterns } from "@/lib/firebase";
 import type { Architecture, Pattern } from "@/lib/types";
 import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
-import { ArchitectureGrid } from "@/components/architecture-grid";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { PatternCard } from "@/components/pattern-card";
 
 export function Architectures() {
   const [architectures, setArchitectures] = useState<Architecture[]>([]);
@@ -17,27 +19,77 @@ export function Architectures() {
     });
   }, []);
 
+  const getPatternsByArchitecture = (archSlug: string) =>
+    patterns.filter((p) => p.architectures.includes(archSlug));
+
   return (
     <div className="flex flex-col min-h-screen bg-background text-foreground">
       <Header />
+
       <main className="flex-1 py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
             <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">
               Arquitecturas de Software
             </h1>
+            <p className="text-xl text-gray-600 dark:text-gray-400 max-w-3xl mx-auto">
+              Explora los patrones arquitecturales modernos que definen cómo estructurar
+              aplicaciones escalables y mantenibles.
+            </p>
           </div>
+
           {isLoading ? (
             <div className="text-center py-12">
               <p className="text-gray-500 dark:text-gray-400 text-lg">
-                Cargando información...
+                Cargando arquitecturas...
               </p>
             </div>
           ) : (
-            <ArchitectureGrid architectures={architectures} patterns={patterns} />
+            <div className="grid gap-8">
+              {architectures.map((architecture) => {
+                const relatedPatterns = getPatternsByArchitecture(architecture.slug);
+
+                return (
+                  <Card key={architecture.slug} className="overflow-hidden">
+                    <CardHeader>
+                      <div className="flex items-center gap-4">
+                        <div
+                          className={`w-16 h-16 bg-gradient-to-br ${architecture.color} rounded-xl flex items-center justify-center`}
+                        >
+                          <i className={`fas fa-${architecture.icon} text-white text-2xl`} />
+                        </div>
+                        <div className="flex-1">
+                          <CardTitle className="text-2xl mb-2">{architecture.name}</CardTitle>
+                          <p className="text-gray-600 dark:text-gray-400">
+                            {architecture.description}
+                          </p>
+                        </div>
+                        <Badge variant="secondary" className="ml-auto">
+                          {relatedPatterns.length} patrones
+                        </Badge>
+                      </div>
+                    </CardHeader>
+
+                    {relatedPatterns.length > 0 && (
+                      <CardContent>
+                        <h4 className="text-lg font-semibold mb-4 text-gray-900 dark:text-white">
+                          Patrones relacionados
+                        </h4>
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                          {relatedPatterns.map((pattern) => (
+                            <PatternCard key={pattern.slug} pattern={pattern} />
+                          ))}
+                        </div>
+                      </CardContent>
+                    )}
+                  </Card>
+                );
+              })}
+            </div>
           )}
         </div>
       </main>
+
       <Footer />
     </div>
   );

--- a/src/pages/Languages.tsx
+++ b/src/pages/Languages.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from "react";
 import { Header } from "@/components/header";
 import { Footer } from "@/components/footer";
-import { LanguageGrid } from "@/components/language-grid";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { PatternCard } from "@/components/pattern-card";
 import { getLanguages, getPatterns } from "@/lib/firebase";
 import type { Language, Pattern } from "@/lib/types";
 
@@ -17,6 +19,14 @@ export function Languages() {
     });
   }, []);
 
+  const languageList = languages.filter((l) => !l.isFramework);
+  const frameworkList = languages.filter((l) => l.isFramework);
+
+  const getPatternsByTechnology = (tech: string, isFramework: boolean) =>
+    patterns.filter((p) =>
+      isFramework ? p.frameworks.includes(tech) : p.languages.includes(tech)
+    );
+
   return (
     <div className="flex flex-col min-h-screen bg-background text-foreground">
       <Header />
@@ -27,6 +37,9 @@ export function Languages() {
             <h1 className="text-4xl font-bold text-gray-900 dark:text-white mb-4">
               Lenguajes y Frameworks
             </h1>
+            <p className="text-xl text-gray-600 dark:text-gray-400 max-w-3xl mx-auto">
+              Descubre cómo implementar patrones de diseño en diferentes lenguajes de programación y frameworks.
+            </p>
           </div>
 
           {isLoading ? (
@@ -36,7 +49,97 @@ export function Languages() {
               </p>
             </div>
           ) : (
-            <LanguageGrid languages={languages} patterns={patterns} />
+            <div className="space-y-12">
+              {/* Languages Section */}
+              <section>
+                <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-8">
+                  Lenguajes de Programación
+                </h2>
+                <div className="grid gap-8">
+                  {languageList.map((language) => {
+                    const languagePatterns = getPatternsByTechnology(language.slug, false);
+
+                    return (
+                      <Card key={language.slug} className="overflow-hidden">
+                        <CardHeader>
+                          <div className="flex items-center gap-4">
+                            <div
+                              className={`w-16 h-16 bg-gradient-to-br ${language.color} rounded-xl flex items-center justify-center`}
+                            >
+                              <i className={`fab fa-${language.icon} text-white text-2xl`} />
+                            </div>
+                            <div className="flex-1">
+                              <CardTitle className="text-2xl mb-2">{language.name}</CardTitle>
+                              <p className="text-gray-600 dark:text-gray-400">
+                                Patrones implementados en {language.name}
+                              </p>
+                            </div>
+                            <Badge variant="secondary" className="ml-auto">
+                              {languagePatterns.length} patrones
+                            </Badge>
+                          </div>
+                        </CardHeader>
+
+                        {languagePatterns.length > 0 && (
+                          <CardContent>
+                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                              {languagePatterns.map((pattern) => (
+                                <PatternCard key={pattern.slug} pattern={pattern} />
+                              ))}
+                            </div>
+                          </CardContent>
+                        )}
+                      </Card>
+                    );
+                  })}
+                </div>
+              </section>
+
+              {/* Frameworks Section */}
+              <section>
+                <h2 className="text-3xl font-bold text-gray-900 dark:text-white mb-8">
+                  Frameworks
+                </h2>
+                <div className="grid gap-8">
+                  {frameworkList.map((framework) => {
+                    const frameworkPatterns = getPatternsByTechnology(framework.slug, true);
+
+                    return (
+                      <Card key={framework.slug} className="overflow-hidden">
+                        <CardHeader>
+                          <div className="flex items-center gap-4">
+                            <div
+                              className={`w-16 h-16 bg-gradient-to-br ${framework.color} rounded-xl flex items-center justify-center`}
+                            >
+                              <i className={`fab fa-${framework.icon} text-white text-2xl`} />
+                            </div>
+                            <div className="flex-1">
+                              <CardTitle className="text-2xl mb-2">{framework.name}</CardTitle>
+                              <p className="text-gray-600 dark:text-gray-400">
+                                Patrones implementados con {framework.name}
+                              </p>
+                            </div>
+                            <Badge variant="secondary" className="ml-auto">
+                              {frameworkPatterns.length} patrones
+                            </Badge>
+                          </div>
+                        </CardHeader>
+
+                        {frameworkPatterns.length > 0 && (
+                          <CardContent>
+                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                              {frameworkPatterns.map((pattern) => (
+                                <PatternCard key={pattern.slug} pattern={pattern} />
+                              ))}
+                            </div>
+                          </CardContent>
+                        )}
+                      </Card>
+                    );
+                  })}
+                </div>
+              </section>
+            </div>
           )}
         </div>
       </main>


### PR DESCRIPTION
## Summary
- better layout for Architectures page
- better layout for Languages page with languages and frameworks sections
- add `isFramework` flag to languages to split frameworks dynamically

## Testing
- `npm run lint` *(fails: 17 errors, 11 warnings)*
- `npm run test:coverage` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68528b75b6e4832799d59e4aa9a4dbfe