### PR TITLE
Update architecture showcase icons and colors

### DIFF
--- a/data/architectures.json
+++ b/data/architectures.json
@@ -4,7 +4,7 @@
     "slug": "hexagonal",
     "name": "Hexagonal",
     "icon": "hexagon",
-    "color": "from-indigo-600 to-purple-700",
+    "color": "from-blue-500 to-indigo-600",
     "description": "Aísla el dominio de detalles externos mediante puertos y adaptadores.",
     "patternCount": 0
   },
@@ -13,7 +13,7 @@
     "slug": "ddd",
     "name": "Domain Driven Design",
     "icon": "building",
-    "color": "from-amber-600 to-orange-700",
+    "color": "from-green-500 to-teal-600",
     "description": "Modela software alrededor del dominio del negocio.",
     "patternCount": 0
   },
@@ -31,7 +31,7 @@
     "slug": "event-driven",
     "name": "Event-Driven",
     "icon": "bolt",
-    "color": "from-yellow-400 to-orange-500",
+    "color": "from-orange-500 to-red-600",
     "description": "Arquitectura basada en la producción y consumo de eventos.",
     "patternCount": 0
   },
@@ -40,7 +40,7 @@
     "slug": "microservices",
     "name": "Microservicios",
     "icon": "layers",
-    "color": "from-fuchsia-500 to-pink-600",
+    "color": "from-pink-500 to-rose-600",
     "description": "Divide la aplicación en servicios pequeños y autónomos.",
     "patternCount": 0
   }

--- a/data/languages.json
+++ b/data/languages.json
@@ -4,7 +4,7 @@
     "slug": "javascript",
     "name": "JavaScript",
     "icon": "file-code",
-    "color": "from-yellow-400 to-yellow-600",
+    "color": "from-yellow-500 to-amber-600",
     "description": "Lenguaje de programación interpretado utilizado principalmente en la web.",
     "patternsCount": 0,
     "isFramework": false
@@ -14,7 +14,7 @@
     "slug": "php",
     "name": "PHP",
     "icon": "server",
-    "color": "from-indigo-600 to-violet-700",
+    "color": "from-indigo-500 to-purple-600",
     "description": "Lenguaje de programación del lado del servidor enfocado en la web.",
     "patternsCount": 0,
     "isFramework": false
@@ -24,7 +24,7 @@
     "slug": "react",
     "name": "React",
     "icon": "atom",
-    "color": "from-sky-500 to-blue-700",
+    "color": "from-sky-500 to-blue-600",
     "description": "Biblioteca de JavaScript para construir interfaces de usuario.",
     "patternsCount": 0,
     "isFramework": true
@@ -34,7 +34,7 @@
     "slug": "vue",
     "name": "Vue.js",
     "icon": "triangle",
-    "color": "from-emerald-500 to-green-700",
+    "color": "from-green-500 to-emerald-600",
     "description": "Framework progresivo de JavaScript para interfaces de usuario.",
     "patternsCount": 0,
     "isFramework": true
@@ -44,7 +44,7 @@
     "slug": "symfony",
     "name": "Symfony",
     "icon": "box",
-    "color": "from-gray-600 to-gray-800",
+    "color": "from-gray-500 to-gray-600",
     "description": "Framework PHP para aplicaciones web robustas.",
     "patternsCount": 0,
     "isFramework": true

--- a/src/components/architecture-showcase.tsx
+++ b/src/components/architecture-showcase.tsx
@@ -1,25 +1,7 @@
 import { useState, useEffect } from "react";
 import { getArchitectures, getPatterns } from "@/lib/firebase";
 import type { Architecture, Pattern } from "@/lib/types";
-import { Building2, Layers, Zap, Users, Database, GitBranch, Settings } from "lucide-react";
-
-const getArchitectureIcon = (iconName: string) => {
-  const iconMap: Record<string, React.ComponentType<any>> = {
-    'building': Building2,
-    'layer-group': Layers,
-    'bolt': Zap,
-    'users': Users,
-    'database': Database,
-    'code-branch': GitBranch,
-    'cog': Settings,
-    'hexagon': Building2,
-    'cube': Layers,
-    'lightning': Zap
-  };
-  
-  const IconComponent = iconMap[iconName] || Building2;
-  return <IconComponent className="text-white" size={24} />;
-};
+import { getIconComponent } from "@/lib/icon-map";
 
 export function ArchitectureShowcase() {
   const [architectures, setArchitectures] = useState<Architecture[]>([]);
@@ -66,7 +48,10 @@ export function ArchitectureShowcase() {
               className="bg-white dark:bg-slate-800 rounded-xl p-6 border border-gray-200 dark:border-slate-700 hover:shadow-lg transition-shadow cursor-pointer"
             >
               <div className={`w-16 h-16 bg-gradient-to-br ${architecture.color} rounded-lg flex items-center justify-center mb-4 mx-auto`}>
-                {getArchitectureIcon(architecture.icon)}
+                {(() => {
+                  const Icon = getIconComponent(architecture.icon);
+                  return <Icon className="text-white" size={24} />;
+                })()}
               </div>
               <h3 className="text-lg font-semibold text-center mb-2 text-gray-900 dark:text-white">
                 {architecture.name}


### PR DESCRIPTION
## Summary
- use shared `getIconComponent` in ArchitectureShowcase
- adjust colors for Hexagonal, Domain Driven Design, Event-Driven and Microservices
- unify gradient colors for languages/frameworks

## Testing
- `npm run lint --silent` *(fails: many lint errors)*
- `npm run build --silent`


------
https://chatgpt.com/codex/tasks/task_e_68529edbce0483279c9dcfcc46e61402